### PR TITLE
Fixed issue of server certificate verification failed on verilator git URL used in Dockfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt -y install \
                     python3-dev libboost-all-dev 
 
 RUN mkdir /opt/tools_builds
-RUN git clone https://github.com/verilator/verilator /opt/tools_builds/verilator && \
+RUN git clone https://git.veripool.org/git/verilator /opt/tools_builds/verilator && \
         cd /opt/tools_builds/verilator && \
         git checkout stable
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt -y install \
                     python3-dev libboost-all-dev 
 
 RUN mkdir /opt/tools_builds
-RUN git clone https://git.veripool.org/git/verilator /opt/tools_builds/verilator && \
+RUN git clone https://github.com/verilator/verilator /opt/tools_builds/verilator && \
         cd /opt/tools_builds/verilator && \
         git checkout stable
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt -y install \
                     qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools \
                     python3-dev libboost-all-dev 
 
+# Update certificate of git.veripool.org
+RUN openssl s_client -showcerts -servername git.veripool.org -connect git.veripool.org:443 </dev/null 2>/dev/null | sed -n -e '/BEGIN\ CERTIFICATE/,/END\ CERTIFICATE/ p' > git-veripool-org.pem
+RUN cat git-veripool-org.pem | tee -a /etc/ssl/certs/ca-certificates.crt
+
 RUN mkdir /opt/tools_builds
 RUN git clone https://git.veripool.org/git/verilator /opt/tools_builds/verilator && \
         cd /opt/tools_builds/verilator && \


### PR DESCRIPTION
Hi @srjilarious,
Thank you for the great stuff on the FPGA design. I'm finding it useful.
I am building simulation tools from the Setup Container step in the Docker Build Setup . 

I encountered an issue on the step `git clone https://github.com/verilator/verilator` in the setup script `docker_build.sh`, it returned "fatal: unable to access 'https://git.veripool.org/git/verilator': server certificate verification failed. CAfile: none CRLfile: none".

The first solution I thought of is directly replacing the URL to GitHub link of Verilator on `991b82` commit. I did more researching and found that the root cause is [Let's Encrypt root CA(certificate authority) has expired on September 2021](https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/), so I provided a new commit `4a2fc14` which updates certificate of **git.veripool.org** before doing `git clone`.